### PR TITLE
Throw Errors received from Redis

### DIFF
--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -42,6 +42,9 @@ class RedisConnection{
     _future = _future.then((_) =>
         RedisParser.parseredisresponse(_stream)
         .then((v) => completer.complete(v))
+        .catchError((error) {
+          completer.completeError(error);
+        })
     );
     return completer.future;
   }

--- a/lib/redisparser.dart
+++ b/lib/redisparser.dart
@@ -60,9 +60,9 @@ class RedisParser{
     });
   }
   
-  static Future parseredisresponse(LazyStream s){
+  static Future parseredisresponse(LazyStream s) {
     return s.take_n(1)
-    .then((list){
+    .then((list) async {
        int cmd = list[0];
        switch(cmd){
          case TYPE_SS:
@@ -74,7 +74,7 @@ class RedisParser{
          case TYPE_BULK:
            return parseBulk(s);
          case TYPE_ERROR:
-           return parseError(s);
+           throw await parseError(s);
          default:
            throw("got element that cant not be parsed");
        }
@@ -89,7 +89,7 @@ class RedisParser{
   }
   
   static Future<RedisError> parseError(LazyStream s){
-    return parseSimpleString(s).then((str) => new RedisError(str));
+    return parseSimpleString(s).then((str) => RedisError(str));
   }
   
   static Future<int> parseInt(LazyStream s){

--- a/test/main.dart
+++ b/test/main.dart
@@ -10,8 +10,8 @@
 library testredis;
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:io';
+
 import '../lib/redis.dart';
 
 part 'testcas.dart';
@@ -20,6 +20,7 @@ part 'testperformance.dart';
 part 'testpubsub.dart';
 part 'testlua.dart';
 part 'testunicode.dart';
+part 'testerror.dart';
 
 
 Future testing_performance(Function fun,String name, int rep){
@@ -53,6 +54,7 @@ main(){
   q.add(testing_helper(test_commands_one_by_one(),"one by one")); 
   q.add(testing_helper(testincrcasmultiple(),"CAS"));
   q.add(testing_helper(testluanative(),"eval"));
+  q.add(testing_helper(testError(),"throw RedisError instead of return"));
 
   Future.wait(q)
   .then((_){

--- a/test/testerror.dart
+++ b/test/testerror.dart
@@ -1,0 +1,15 @@
+part of testredis;
+
+Future testError() {
+
+  RedisConnection conn = new RedisConnection();
+  return conn.connect('localhost',6379).then((Command command)  {
+      command.send_object("GARBAGE").then((val) {
+        throw "Expected thrown Error, not value";
+      })
+      .catchError((error) {
+        return true;
+      });
+  });
+
+}


### PR DESCRIPTION
What do you think about throwing errors received from Redis? Otherwise, one has to check the Futures wether they returned an error or the expected data. In my opinion, throwing them directly would be the better way.