### PR TITLE
Convert non-Strings in Lists to Strings before sending to Redis

### DIFF
--- a/lib/redisserialise.dart
+++ b/lib/redisserialise.dart
@@ -54,7 +54,7 @@ class RedisSerialise {
        consumer(_star);
        consumer(_IntToRaw(len));
        consumer(_linesep);
-       object.forEach((v)=>SerialiseConsumable(v,consumer));
+       object.forEach((v)=> SerialiseConsumable(v is int ? v.toString() : v,consumer));
      }
      else if(object is int){
        consumer(_semicol);

--- a/test/main.dart
+++ b/test/main.dart
@@ -20,6 +20,7 @@ part 'testperformance.dart';
 part 'testpubsub.dart';
 part 'testlua.dart';
 part 'testunicode.dart';
+part 'testconversion.dart';
 
 
 Future testing_performance(Function fun,String name, int rep){
@@ -53,6 +54,7 @@ main(){
   q.add(testing_helper(test_commands_one_by_one(),"one by one")); 
   q.add(testing_helper(testincrcasmultiple(),"CAS"));
   q.add(testing_helper(testluanative(),"eval"));
+  q.add(testing_helper(testConversion(),"Convert ints to strings when in Array"));
 
   Future.wait(q)
   .then((_){

--- a/test/testconversion.dart
+++ b/test/testconversion.dart
@@ -1,0 +1,18 @@
+part of testredis;
+
+Future testConversion() {
+
+  RedisConnection conn = new RedisConnection();
+  return conn.connect('localhost',6379).then((Command command)  {
+      command.send_object(["SADD", "test_list", 1]).then((val) {
+        if(val is RedisError) {
+          throw "Expected redis-dart to convert integers to bulk strings when contained in array.";
+        }
+        return true;
+      })
+      .catchError((error) {
+        throw "Expected redis-dart to convert integers to bulk strings when contained in array.";
+      });
+  });
+
+}


### PR DESCRIPTION
As far as I understand the protocol, arrays can just contain Bulk Strings when sending to the server, but when working with integers, calling toString everytime is quite a hassle. 

```
int id = 3;
# Before:
send_object(["SADD", "test", id.toString()]);

# After:
send_object(["SADD", "test", id]);
```

Test is inside.