### PR TITLE
Migration to dart 2.12

### DIFF
--- a/lib/cas.dart
+++ b/lib/cas.dart
@@ -27,7 +27,7 @@ class Cas {
     List<String> watchcmd = ["WATCH"];
     watchcmd.addAll(watching_keys);
     return Future.doWhile(() {
-      _completer_bool = new Completer();
+      _completer_bool = Completer();
       _cmd.send_object(watchcmd).then((_) {
         func();
       });
@@ -52,7 +52,7 @@ class Cas {
         } else {
           // exec completes only with valid response
           _completer_bool.completeError(
-              RedisError("exec response is not expceted, but is $resp"));
+              RedisError("exec response is not expected, but is $resp"));
         }
       }).catchError((e) {
         // dont do anything

--- a/lib/cas.dart
+++ b/lib/cas.dart
@@ -1,4 +1,3 @@
-
 /*
  * Free software licenced under 
  * GNU AFFERO GENERAL PUBLIC LICENSE
@@ -10,56 +9,55 @@
 
 part of redis;
 
-class Cas{
+class Cas {
   Command _cmd;
-  Completer<bool> _completer_bool;
-  
-  /// Class for  CAS  check-and-set pattern  
-  /// Construct with Command and call  
-  /// watch() and multiAndExec()  
-  Cas(this._cmd){}
-  
-  /// watch takes list of watched keys and  
-  /// function that is executed  
-  /// during CAS opertion  
-  /// 
-  Future watch(List<String> watching_keys,  func()){
-     //return _cmd.send_object(["TRANS"]);
+  late Completer<bool> _completer_bool;
+
+  /// Class for  CAS  check-and-set pattern
+  /// Construct with Command and call
+  /// watch() and multiAndExec()
+  Cas(this._cmd) {}
+
+  /// watch takes list of watched keys and
+  /// function that is executed
+  /// during CAS opertion
+  ///
+  Future watch(List<String> watching_keys, func()) {
+    //return _cmd.send_object(["TRANS"]);
     List<String> watchcmd = ["WATCH"];
     watchcmd.addAll(watching_keys);
-    return Future.doWhile((){
+    return Future.doWhile(() {
       _completer_bool = new Completer();
-      _cmd.send_object(watchcmd).then((_){
+      _cmd.send_object(watchcmd).then((_) {
         func();
       });
       return _completer_bool.future;
     });
   }
-  
-  /// multiAndExec takes function 
+
+  /// multiAndExec takes function
   /// to complete CAS as Transaction
-  /// passed function takes Transation
-  /// as only parameter and should be used to 
+  /// passed function takes Transaction
+  /// as only parameter and should be used to
   /// complete transaction
-  /// 
-  /// !!! DO NOT call exec() on Transation
-  
-  Future multiAndExec(Future func(Transation)){
-    return _cmd.multi().then((Transaction _trans){
+  ///
+  /// !!! DO NOT call exec() on Transaction
+
+  Future multiAndExec(Future func(Transation)) {
+    return _cmd.multi().then((Transaction _trans) {
       func(_trans);
-      return _trans.exec().then((var resp){
-        if (resp == "OK"){
+      return _trans.exec().then((var resp) {
+        if (resp == "OK") {
           _completer_bool.complete(false); //terminate Future.doWhile
-        }
-        else{
+        } else {
           // exec completes only with valid response
-          _completer_bool.completeError(RedisError("exec response is not expceted, but is $resp"));
+          _completer_bool.completeError(
+              RedisError("exec response is not expceted, but is $resp"));
         }
-      })
-      .catchError((e){
-          // dont do anything
-         _completer_bool.complete(true); // retry
-       }, test: (e) => e is TransactionError);
+      }).catchError((e) {
+        // dont do anything
+        _completer_bool.complete(true); // retry
+      }, test: (e) => e is TransactionError);
     });
   }
 }

--- a/lib/command.dart
+++ b/lib/command.dart
@@ -50,7 +50,7 @@ class Command {
   /// Transations are started with multi and completed with exec()
   Future<Transaction> multi() {
     //multi retun transation as future
-    return send_object(["MULTI"]).then((_) => new Transaction(this));
+    return send_object(["MULTI"]).then((_) => Transaction(this));
   }
 
   RedisConnection get_connection() {

--- a/lib/command.dart
+++ b/lib/command.dart
@@ -7,48 +7,49 @@
  * Luka Rahne
  */
 
-
 part of redis;
 
 class Command {
   /*RedisConnection*/ var _connection;
 
-  Command(this._connection){}
-  
-  /// Serialise and send data to server  
-  /// 
-  /// Data can be any object recognised by Redis    
-  /// List, integer, Bulk, null and composite of those   
-  /// Redis command is List<String>    
-  ///     
+  Command(this._connection) {}
+
+  /// Serialise and send data to server
+  ///
+  /// Data can be any object recognised by Redis
+  /// List, integer, Bulk, null and composite of those
+  /// Redis command is List<String>
+  ///
   /// example SET:
   ///     send_object(["SET","key","value"]);
-  Future send_object(Object obj){
-    try{
+  Future send_object(Object obj) {
+    try {
       // RedisSerialise.Serialise
       return _connection._sendraw(RedisSerialise.Serialise(obj));
-    } catch(e){
-	    return new Future.error(e);
+    } catch (e) {
+      return Future.error(e);
     }
   }
-  
+
   /// return future that completes when
   /// all prevous packets are processed
-  Future send_nothing() => _connection._getdummy();
-  
+  Future? send_nothing() => _connection._getdummy();
+
   /// Set socket settings for sending transations
-  /// 
-  ///  This is optimisation and not requrement. 
-  void pipe_start() => _connection.disable_nagle(false); //we want to use sockets buffering
+  ///
+  ///  This is optimisation and not requrement.
+  void pipe_start() =>
+      _connection.disable_nagle(false); //we want to use sockets buffering
   /// Requred to be called after last piping command
-  void pipe_end() =>   _connection.disable_nagle(true);
-  
+  void pipe_end() => _connection.disable_nagle(true);
+
   //commands in future, we will add more commands
-  Future set(String key, String value) => send_object(["SET",key,value]);
-  Future get(String key) => send_object(["GET",key]);
-  
+  Future? set(String key, String value) => send_object(["SET", key, value]);
+  Future? get(String key) => send_object(["GET", key]);
+
   /// Transations are started with multi and completed with exec()
-  Future<Transaction> multi(){ //multi retun transation as future
+  Future<Transaction> multi() {
+    //multi retun transation as future
     return send_object(["MULTI"]).then((_) => new Transaction(this));
   }
 
@@ -56,4 +57,3 @@ class Command {
     return _connection;
   }
 }
-  

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -13,16 +13,16 @@ part of redis;
 class RedisConnection {
   Socket? _socket;
   LazyStream? _stream;
-  Future _future = new Future.value();
-  RedisParser parser = new RedisParser();
+  Future _future = Future.value();
+  RedisParser parser = RedisParser();
 
   /// connect on Redis server as client
   Future<Command> connect(host, port) {
     return Socket.connect(host, port).then((Socket sock) {
       _socket = sock;
       disable_nagle(true);
-      _stream = new LazyStream.fromstream(_socket!);
-      return new Command(this);
+      _stream = LazyStream.fromstream(_socket!);
+      return Command(this);
     });
   }
 
@@ -31,8 +31,8 @@ class RedisConnection {
     return SecureSocket.connect(host, port).then((SecureSocket sock) {
       _socket = sock;
       disable_nagle(true);
-      _stream = new LazyStream.fromstream(_socket!);
-      return new Command(this);
+      _stream = LazyStream.fromstream(_socket!);
+      return Command(this);
     });
   }
 

--- a/lib/connection.dart
+++ b/lib/connection.dart
@@ -7,13 +7,12 @@
  * Luka Rahne
  */
 
-
 part of redis;
 
 /// Class for server connection on server
 class RedisConnection {
-  Socket _socket = null;
-  LazyStream _stream = null;
+  Socket? _socket;
+  LazyStream? _stream;
   Future _future = new Future.value();
   RedisParser parser = new RedisParser();
 
@@ -22,7 +21,7 @@ class RedisConnection {
     return Socket.connect(host, port).then((Socket sock) {
       _socket = sock;
       disable_nagle(true);
-      _stream = new LazyStream.fromstream(_socket);
+      _stream = new LazyStream.fromstream(_socket!);
       return new Command(this);
     });
   }
@@ -32,7 +31,7 @@ class RedisConnection {
     return SecureSocket.connect(host, port).then((SecureSocket sock) {
       _socket = sock;
       disable_nagle(true);
-      _stream = new LazyStream.fromstream(_socket);
+      _stream = new LazyStream.fromstream(_socket!);
       return new Command(this);
     });
   }
@@ -41,14 +40,14 @@ class RedisConnection {
   Future<Command> connectWithSocket(Socket s) async {
     _socket = s;
     disable_nagle(true);
-    _stream = LazyStream.fromstream(_socket);
+    _stream = LazyStream.fromstream(_socket!);
     return Command(this);
   }
 
   /// close connection to Redis server
   Future close() {
-    _stream.close();
-    return _socket.close();
+    _stream!.close();
+    return _socket!.close();
   }
 
   //this doesnt send anything
@@ -56,13 +55,14 @@ class RedisConnection {
   //it parse it and execute future
   Future _senddummy() {
     _future = _future.then((_) {
-      return RedisParser.parseredisresponse(_stream);
+      return RedisParser.parseredisresponse(_stream!);
     });
     return _future;
   }
 
   // return future that complets
   // when all prevous _future finished
+  // ignore: unused_element
   Future _getdummy() {
     _future = _future.then((_) {
       return "dummy data";
@@ -70,12 +70,13 @@ class RedisConnection {
     return _future;
   }
 
+  // ignore: unused_element
   Future _sendraw(List data) {
-    _socket.add(data);
+    _socket!.add(data as List<int>);
     return _senddummy();
   }
 
   void disable_nagle(bool v) {
-    _socket.setOption(SocketOption.TCP_NODELAY, v);
+    _socket!.setOption(SocketOption.tcpNoDelay, v);
   }
 }

--- a/lib/lazystream.dart
+++ b/lib/lazystream.dart
@@ -22,7 +22,7 @@ class StreamNext<T> {
   late int _npack;
   late bool done;
   StreamNext.fromstream(Stream<T> stream) {
-    _queue = new Queue<Completer<T>>();
+    _queue = Queue<Completer<T>>();
     _nfut = 0;
     _npack = 0;
     done = false;
@@ -35,7 +35,7 @@ class StreamNext<T> {
       c.complete(event);
       _nfut -= 1;
     } else {
-      Completer<T> c = new Completer<T>();
+      Completer<T> c = Completer<T>();
       c.complete(event);
       _queue.addLast(c);
       _npack += 1;
@@ -62,7 +62,7 @@ class StreamNext<T> {
         return Future<T>.error("stream closed");
       }
       _nfut += 1;
-      _queue.addLast(new Completer<T>());
+      _queue.addLast(Completer<T>());
       return _queue.last.future;
     } else {
       Completer<T> c = _queue.removeFirst();
@@ -79,7 +79,7 @@ class LazyStream {
   late List<int> _return;
   late Iterator<int> _iter;
   LazyStream.fromstream(Stream<List<int>> stream) {
-    _stream = new StreamNext<List<int>>.fromstream(stream);
+    _stream = StreamNext<List<int>>.fromstream(stream);
     _return = <int>[];
     _remainder = <int>[];
     _iter = _remainder.iterator;
@@ -97,7 +97,7 @@ class LazyStream {
   Future<List<int>> __take_n(int n) {
     int rest = _take_n_helper(n);
     if (rest == 0) {
-      return new Future<List<int>>.value(_return);
+      return Future<List<int>>.value(_return);
     } else {
       return _stream.next().then<List<int>>((List<int> pack) {
         _remainder = pack;

--- a/lib/lazystream.dart
+++ b/lib/lazystream.dart
@@ -16,27 +16,25 @@
 part of redis;
 
 // like Stream but has method next for simple reading
-class StreamNext<T>  {
-  StreamSubscription<T> _ss;
-  Queue<Completer<T>> _queue;
-  int _nfut;
-  int _npack;
-  bool done;
-  StreamNext.fromstream(Stream<T> stream){
+class StreamNext<T> {
+  late Queue<Completer<T>> _queue;
+  late int _nfut;
+  late int _npack;
+  late bool done;
+  StreamNext.fromstream(Stream<T> stream) {
     _queue = new Queue<Completer<T>>();
     _nfut = 0;
     _npack = 0;
     done = false;
-    _ss = stream.listen(onData  ,onError : this.onError  , onDone : this.onDone );
+    stream.listen(onData, onError: this.onError, onDone: this.onDone);
   }
 
-  void onData(T event){
-    if(_nfut >= 1){
-      Completer  c = _queue.removeFirst();
+  void onData(T event) {
+    if (_nfut >= 1) {
+      Completer c = _queue.removeFirst();
       c.complete(event);
-      _nfut -= 1; 
-    }
-    else{
+      _nfut -= 1;
+    } else {
       Completer<T> c = new Completer<T>();
       c.complete(event);
       _queue.addLast(c);
@@ -44,70 +42,64 @@ class StreamNext<T>  {
     }
   }
 
-  void onError(error){
+  void onError(error) {
     done = true;
-    if(_nfut >= 1){
+    if (_nfut >= 1) {
       _nfut = 0;
-      for(Completer<T> e in  _queue){
+      for (Completer<T> e in _queue) {
         e.completeError(error);
       }
     }
   }
 
-  void onDone(){
+  void onDone() {
     onError("stream is closed");
   }
 
-  Future<T> next(){
-    if(_npack == 0){
-      if(done) {
+  Future<T> next() {
+    if (_npack == 0) {
+      if (done) {
         return Future<T>.error("stream closed");
       }
       _nfut += 1;
       _queue.addLast(new Completer<T>());
       return _queue.last.future;
-    }
-    else {
+    } else {
       Completer<T> c = _queue.removeFirst();
       _npack -= 1;
       return c.future;
     }
   }
-  
 }
 
-// it 
+// it
 class LazyStream {
-  
-  StreamNext<List<int>> _stream;
-  List<int> _remainder;
-  List<int> _return;
-  int _start_index;
-  Iterator<int> _iter;
-  LazyStream.fromstream(Stream<List<int>> stream){
+  late StreamNext<List<int>> _stream;
+  late List<int> _remainder;
+  late List<int> _return;
+  late Iterator<int> _iter;
+  LazyStream.fromstream(Stream<List<int>> stream) {
     _stream = new StreamNext<List<int>>.fromstream(stream);
-    _start_index = 0;
-    _return = new List<int>();
-    _remainder = new List<int>();
+    _return = <int>[];
+    _remainder = <int>[];
     _iter = _remainder.iterator;
   }
-  
-  void close(){
-     _stream.onDone();
+
+  void close() {
+    _stream.onDone();
   }
 
   Future<List<int>> take_n(int n) {
-    _return = new List<int>();
+    _return = <int>[];
     return __take_n(n);
   }
-  
+
   Future<List<int>> __take_n(int n) {
     int rest = _take_n_helper(n);
-    if (rest == 0){
-        return new Future<List<int>>.value(_return);
-    }
-    else {
-      return _stream.next().then<List<int>>((List<int> pack){
+    if (rest == 0) {
+      return new Future<List<int>>.value(_return);
+    } else {
+      return _stream.next().then<List<int>>((List<int> pack) {
         _remainder = pack;
         _iter = _remainder.iterator;
         return __take_n(rest);
@@ -116,26 +108,24 @@ class LazyStream {
   }
 
   // return remining n
-  int _take_n_helper(int n){
-    while(n > 0 && _iter.moveNext()){
+  int _take_n_helper(int n) {
+    while (n > 0 && _iter.moveNext()) {
       _return.add(_iter.current);
       n--;
     }
     return n;
   }
 
-
   Future<List<int>> take_while(bool Function(int) pred) {
-    _return = new List<int>();
+    _return = <int>[];
     return __take_while(pred);
   }
-  
+
   Future<List<int>> __take_while(bool Function(int) pred) {
-    if (_take_while_helper(pred)){
-        return Future<List<int>>.value(_return);
-    }
-    else {
-      return _stream.next().then<List<int>>((List<int> rem){
+    if (_take_while_helper(pred)) {
+      return Future<List<int>>.value(_return);
+    } else {
+      return _stream.next().then<List<int>>((List<int> rem) {
         _remainder = rem;
         _iter = _remainder.iterator;
         return __take_while(pred);
@@ -144,16 +134,14 @@ class LazyStream {
   }
 
   // return true when exaused (when predicate returns false)
-  bool _take_while_helper(bool Function(int) pred){
-    while(_iter.moveNext()){
-      if(pred(_iter.current)){
+  bool _take_while_helper(bool Function(int) pred) {
+    while (_iter.moveNext()) {
+      if (pred(_iter.current)) {
         _return.add(_iter.current);
-      }
-      else {
+      } else {
         return true;
       }
     }
     return false;
   }
 }
-

--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -5,51 +5,48 @@ class _WarrningPubSubInProgress {
       "It is not allowed to issue commands trough this handler";
 }
 
-class PubSub{
-  Command _command;
+class PubSub {
+  late Command _command;
   StreamController<List> _stream_controler = new StreamController<List>();
-  Future _forever;
-  
-  PubSub(Command command){
-    _command=new  Command(command._connection);
-    _forever = command.send_nothing().then((_){
+
+  PubSub(Command command) {
+    _command = new Command(command._connection);
+    command.send_nothing()!.then((_) {
       //override socket with warrning
-      command._connection = new _WarrningPubSubInProgress(); 
+      command._connection = new _WarrningPubSubInProgress();
       // listen and process forever
-      return Future.doWhile((){
-          return _command._connection._senddummy()
-          .then<bool>((var data){
-              _stream_controler.add(data);
-               return true;
-          });
+      return Future.doWhile(() {
+        return _command._connection._senddummy().then<bool>((var data) {
+          _stream_controler.add(data);
+          return true;
+        });
       });
     });
   }
-  
-  
-  Stream getStream(){
+
+  Stream getStream() {
     return _stream_controler.stream;
   }
-  
-  void subscribe(List<String> s){
-    _sendcmd_and_list("SUBSCRIBE",s);
-  }
-  
-  void  psubscribe(List<String> s){
-    _sendcmd_and_list("PSUBSCRIBE",s);
-  }
-  
-  void unsubscribe(List<String> s){
-    _sendcmd_and_list("UNSUBSCRIBE",s);
+
+  void subscribe(List<String> s) {
+    _sendcmd_and_list("SUBSCRIBE", s);
   }
 
-  void punsubscribe(List<String> s){
-    _sendcmd_and_list("PUNSUBSCRIBE",s);
+  void psubscribe(List<String> s) {
+    _sendcmd_and_list("PSUBSCRIBE", s);
   }
-  
-  void _sendcmd_and_list(String cmd,List<String> s){
+
+  void unsubscribe(List<String> s) {
+    _sendcmd_and_list("UNSUBSCRIBE", s);
+  }
+
+  void punsubscribe(List<String> s) {
+    _sendcmd_and_list("PUNSUBSCRIBE", s);
+  }
+
+  void _sendcmd_and_list(String cmd, List<String> s) {
     List list = [cmd];
     list.addAll(s);
     _command._connection._socket.add(RedisSerialise.Serialise(list));
   }
-} 
+}

--- a/lib/pubsub.dart
+++ b/lib/pubsub.dart
@@ -7,13 +7,13 @@ class _WarrningPubSubInProgress {
 
 class PubSub {
   late Command _command;
-  StreamController<List> _stream_controler = new StreamController<List>();
+  StreamController<List> _stream_controler = StreamController<List>();
 
   PubSub(Command command) {
-    _command = new Command(command._connection);
+    _command = Command(command._connection);
     command.send_nothing()!.then((_) {
       //override socket with warrning
-      command._connection = new _WarrningPubSubInProgress();
+      command._connection = _WarrningPubSubInProgress();
       // listen and process forever
       return Future.doWhile(() {
         return _command._connection._senddummy().then<bool>((var data) {

--- a/lib/redisparser.dart
+++ b/lib/redisparser.dart
@@ -30,8 +30,7 @@ class RedisParser {
       //now check for LF
       return s.take_n(1).then((lf) {
         if (lf[0] != LF) {
-          return new Future.error(
-              RedisRuntimeError("received element is not LF"));
+          return Future.error(RedisRuntimeError("received element is not LF"));
         }
         return list;
       });
@@ -45,7 +44,7 @@ class RedisParser {
       if (data[0] == CR && data[1] == LF) {
         return r;
       } else {
-        return new Future.error(RedisRuntimeError("expeting CRLF"));
+        return Future.error(RedisRuntimeError("expeting CRLF"));
       }
     });
   }
@@ -63,9 +62,9 @@ class RedisParser {
         case TYPE_BULK:
           return parseBulk(s);
         case TYPE_ERROR:
-          return parseError(s).then((e) => new Future.error(e));
+          return parseError(s).then((e) => Future.error(e));
         default:
-          return new Future.error(
+          return Future.error(
               RedisRuntimeError("got element that cant not be parsed"));
       }
     });
@@ -95,7 +94,7 @@ class RedisParser {
         return s.take_n(i).then((lst) => takeCRLF(
             s, UTF8.decode(lst))); //consume CRLF and return decoded list
       } else {
-        return new Future.error(
+        return Future.error(
             RedisRuntimeError("cant process buld data less than -1"));
       }
     });
@@ -108,7 +107,7 @@ class RedisParser {
     Future<List> consumeList(LazyStream s, int len, List lst) {
       assert(len >= 0);
       if (len == 0) {
-        return new Future.value(lst);
+        return Future.value(lst);
       }
       return parseredisresponse(s).then((resp) {
         lst.add(resp);
@@ -126,7 +125,7 @@ class RedisParser {
         List a = [];
         return consumeList(s, i, a);
       } else {
-        return new Future.error(
+        return Future.error(
             RedisRuntimeError("cant process array data less than -1"));
       }
     });

--- a/lib/redisparser.dart
+++ b/lib/redisparser.dart
@@ -9,148 +9,143 @@
 
 part of redis;
 
-
-class RedisParser{
+class RedisParser {
   static final UTF8 = const Utf8Codec();
   static const int CR = 13;
   static const int LF = 10;
-  
+
   static const int TYPE_SS = 43; //+
   static const int TYPE_ERROR = 45; //-
-  static const int TYPE_INT =  58; //:
-  static const int TYPE_BULK =  36; //$
+  static const int TYPE_INT = 58; //:
+  static const int TYPE_BULK = 36; //$
   static const int TYPE_ARRAY = 42; //*
-  
-  
-  //read untill it finds CR and LF 
+
+  //read untill it finds CR and LF
   //by protocol it is enough to find just CR and LF folows
   //this method can be used only on types that complies with such rule
   //it consumes both CR and LF from stream, but is not returned
   static Future read_simple(LazyStream s) {
-    return s.take_while((c) => (c != CR))
-    .then((list) {
-      //takeWile consumed CR from stream, 
+    return s.take_while((c) => (c != CR)).then((list) {
+      //takeWile consumed CR from stream,
       //now check for LF
-      return s.take_n(1).then((lf){
-        if(lf[0] != LF){
-          return new Future.error(RedisRuntimeError("received element is not LF"));
+      return s.take_n(1).then((lf) {
+        if (lf[0] != LF) {
+          return new Future.error(
+              RedisRuntimeError("received element is not LF"));
         }
         return list;
       });
     });
   }
-  
+
   //return Future<r> if next two elemets are CRLF
   //or thows if failed
-  static Future takeCRLF(LazyStream s,r){
-    return s.take_n(2).then((data){
-      if(data[0] == CR && data[1] == LF){
+  static Future takeCRLF(LazyStream s, r) {
+    return s.take_n(2).then((data) {
+      if (data[0] == CR && data[1] == LF) {
         return r;
-      }
-      else{
+      } else {
         return new Future.error(RedisRuntimeError("expeting CRLF"));
       }
     });
   }
-  
+
   static Future parseredisresponse(LazyStream s) {
     return s.take_n(1).then((list) {
-       int cmd = list[0];
-       switch(cmd){
-         case TYPE_SS:
-           return parseSimpleString(s);
-         case TYPE_INT:
-           return parseInt(s);
-         case TYPE_ARRAY:
-           return parseArray(s);
-         case TYPE_BULK:
-           return parseBulk(s);
-         case TYPE_ERROR:
-           return parseError(s).then((e) => new Future.error(e));
-         default:
-           return new Future.error(RedisRuntimeError("got element that cant not be parsed"));
-       }
+      int cmd = list[0];
+      switch (cmd) {
+        case TYPE_SS:
+          return parseSimpleString(s);
+        case TYPE_INT:
+          return parseInt(s);
+        case TYPE_ARRAY:
+          return parseArray(s);
+        case TYPE_BULK:
+          return parseBulk(s);
+        case TYPE_ERROR:
+          return parseError(s).then((e) => new Future.error(e));
+        default:
+          return new Future.error(
+              RedisRuntimeError("got element that cant not be parsed"));
+      }
     });
   }
-  
-  static Future<String> parseSimpleString(LazyStream s){
-    return read_simple(s).then((v){
-         return  UTF8.decode(v);
+
+  static Future<String> parseSimpleString(LazyStream s) {
+    return read_simple(s).then((v) {
+      return UTF8.decode(v);
     });
   }
-  
-  static Future<RedisError> parseError(LazyStream s){
+
+  static Future<RedisError> parseError(LazyStream s) {
     return parseSimpleString(s).then((str) => RedisError(str));
   }
-  
-  static Future<int> parseInt(LazyStream s){
-    return read_simple(s).then((v)=> _ParseIntRaw(v));
+
+  static Future<int> parseInt(LazyStream s) {
+    return read_simple(s).then((v) => _ParseIntRaw(v));
   }
-  
-  static Future parseBulk(LazyStream s){
-    return parseInt(s).then((i){ //get len
-      if(i==-1) //null
-        return null; 
-      if(i>=0){ //i of bulk data
-       return s.take_n(i) 
-       .then((lst) => takeCRLF(s,UTF8.decode(lst))); //consume CRLF and return decoded list
-      }
-      else{
-        return new Future.error(RedisRuntimeError("cant process buld data less than -1"));
+
+  static Future parseBulk(LazyStream s) {
+    return parseInt(s).then((i) {
+      //get len
+      if (i == -1) //null
+        return null;
+      if (i >= 0) {
+        //i of bulk data
+        return s.take_n(i).then((lst) => takeCRLF(
+            s, UTF8.decode(lst))); //consume CRLF and return decoded list
+      } else {
+        return new Future.error(
+            RedisRuntimeError("cant process buld data less than -1"));
       }
     });
   }
-  
+
   //it first consume array as N and then
   //consume  N elements with parseredisresponse function
-  static Future<List> parseArray(LazyStream s){
+  static Future<List> parseArray(LazyStream s) {
     //closure
-    Future<List> consumeList(LazyStream s,int len,List lst){
-      assert(len>=0);
-      if(len==0){
+    Future<List> consumeList(LazyStream s, int len, List lst) {
+      assert(len >= 0);
+      if (len == 0) {
         return new Future.value(lst);
       }
-      return parseredisresponse(s).then((resp){
+      return parseredisresponse(s).then((resp) {
         lst.add(resp);
-        return consumeList(s,len-1,lst);
+        return consumeList(s, len - 1, lst);
       });
     }
+
     //end of closure
-    return parseInt(s).then((i){ //get len
-      if(i==-1) //null
-        return null; 
-      if(i>=0){ //i of array data
-          List a = new List();
-          return consumeList(s,i,a);
-      }
-      else{
-        return new Future.error(RedisRuntimeError("cant process array data less than -1"));
+    return parseInt(s).then((i) {
+      //get len
+      if (i == -1) //null
+        return [null];
+      if (i >= 0) {
+        //i of array data
+        List a = [];
+        return consumeList(s, i, a);
+      } else {
+        return new Future.error(
+            RedisRuntimeError("cant process array data less than -1"));
       }
     });
   }
-  
-  
+
   //maualy parse int from raw data (faster)
-  static int _ParseIntRaw(Iterable<int> arr){
-      int sign = 1;
-      var v = arr.fold(0,(a,b){
-        if(b == 45){
-          if(a != 0)
-            throw RedisRuntimeError("cannot parse int");
-          sign = -1;
-          return 0;
-        }
-        else if ((b >=48) && (b<58)){
-          return a*10+b-48;
-        }
-        else{
-          throw RedisRuntimeError("cannot parse int");
-        }
-      });
-      return v*sign;
+  static int _ParseIntRaw(Iterable<int> arr) {
+    int sign = 1;
+    var v = arr.fold(0, (dynamic a, b) {
+      if (b == 45) {
+        if (a != 0) throw RedisRuntimeError("cannot parse int");
+        sign = -1;
+        return 0;
+      } else if ((b >= 48) && (b < 58)) {
+        return a * 10 + b - 48;
+      } else {
+        throw RedisRuntimeError("cannot parse int");
+      }
+    });
+    return v * sign;
   }
-  
 }
-
-
-

--- a/lib/redisserialise.dart
+++ b/lib/redisserialise.dart
@@ -8,7 +8,7 @@ part of redis;
  * Luka Rahne
  */
 
-Utf8Encoder RedisSerialiseEncoder = new Utf8Encoder();
+Utf8Encoder RedisSerialiseEncoder = Utf8Encoder();
 
 class RedisBulk {
   Iterable<int> iterable;

--- a/lib/redisserialise.dart
+++ b/lib/redisserialise.dart
@@ -8,72 +8,66 @@ part of redis;
  * Luka Rahne
  */
 
-
 Utf8Encoder RedisSerialiseEncoder = new Utf8Encoder();
 
-class RedisBulk{
+class RedisBulk {
   Iterable<int> iterable;
-  /// This clase enables sending Iterable<int> 
+
+  /// This clase enables sending Iterable<int>
   /// as bulk data on redis
   /// it can be used when sending files for example
-  RedisBulk(this.iterable){
-  }
+  RedisBulk(this.iterable) {}
 }
-
 
 class RedisSerialise {
   static final ASCII = const AsciiCodec();
   static final UTF8 = const Utf8Codec();
-  static final  _dollar = ASCII.encode("\$");
-  static final  _star = ASCII.encode("\*");
-  static final  _semicol  = ASCII.encode(":");
+  static final _dollar = ASCII.encode("\$");
+  static final _star = ASCII.encode("\*");
+  static final _semicol = ASCII.encode(":");
   static final _linesep = ASCII.encode("\r\n");
   static final _dollarminus1 = ASCII.encode("\$-1");
-      
-  static List<int> Serialise(object){
-     List<int> s = new List();
-     SerialiseConsumable(object,(v){
-       s.addAll(v);
-     });
-     return s;
+
+  static List<int> Serialise(object) {
+    var s = <int>[];
+    SerialiseConsumable(object, (v) {
+      s.addAll(v as Iterable<int>);
+    });
+    return s;
   }
-  
-  static void SerialiseConsumable(object,Function consumer(Iterable s)){
-     if(object is String){
-       var data = UTF8.encode(object);
-       consumer(_dollar);
-       consumer(_IntToRaw(data.length));
-       consumer(_linesep); 
-       consumer(data);
-       consumer(_linesep);
-     }
-     else if(object is Iterable){
-       int len=object.length;
-       consumer(_star);
-       consumer(_IntToRaw(len));
-       consumer(_linesep);
-       object.forEach((v)=> SerialiseConsumable(v is int ? v.toString() : v,consumer));
-     }
-     else if(object is int){
-       consumer(_semicol);
-       consumer(_IntToRaw(object));
-       consumer(_linesep);
-     }
-     else if(object is RedisBulk){
-       consumer(_dollar);
-       consumer(_IntToRaw(object.iterable.length));
-       consumer(_linesep);
-       consumer(object.iterable);
-     }
-     else if(object == null){
-       consumer(_dollarminus1); //null bulk
-     }
-     else{
-       throw("cant serialise such type");
-     }
+
+  static void SerialiseConsumable(object, void consumer(Iterable s)) {
+    if (object is String) {
+      var data = UTF8.encode(object);
+      consumer(_dollar);
+      consumer(_IntToRaw(data.length));
+      consumer(_linesep);
+      consumer(data);
+      consumer(_linesep);
+    } else if (object is Iterable) {
+      int len = object.length;
+      consumer(_star);
+      consumer(_IntToRaw(len));
+      consumer(_linesep);
+      object.forEach(
+          (v) => SerialiseConsumable(v is int ? v.toString() : v, consumer));
+    } else if (object is int) {
+      consumer(_semicol);
+      consumer(_IntToRaw(object));
+      consumer(_linesep);
+    } else if (object is RedisBulk) {
+      consumer(_dollar);
+      consumer(_IntToRaw(object.iterable.length));
+      consumer(_linesep);
+      consumer(object.iterable);
+    } else if (object == null) {
+      consumer(_dollarminus1); //null bulk
+    } else {
+      throw ("cant serialise such type");
+    }
   }
-  
-  static Iterable<int> _IntToRaw(int n){
+
+  static Iterable<int> _IntToRaw(int n) {
     //if(i>=0 && i < _ints.length)
     //   return _ints[i];
     return ASCII.encode(n.toString());

--- a/lib/transaction.dart
+++ b/lib/transaction.dart
@@ -10,30 +10,29 @@
 part of redis;
 
 class _WarningConnection {
-  noSuchMethod(_) =>
-      throw RedisRuntimeError("Transaction in progress. "
-          "Please complete Transaction with .exec");
+  noSuchMethod(_) => throw RedisRuntimeError("Transaction in progress. "
+      "Please complete Transaction with .exec");
 }
 
-class Transaction extends Command{ 
+class Transaction extends Command {
   Queue<Completer> _queue = new Queue();
-  Command _overrided_command;
+  late Command _overrided_command;
   bool transaction_completed = false;
-  
-  Transaction(Command command):super(command._connection){
+
+  Transaction(Command command) : super(command._connection) {
     _overrided_command = command;
-    //we override his _connection, during transaction 
+    //we override his _connection, during transaction
     //it is best to point out where problem is
     command._connection = new _WarningConnection();
-
   }
-  
-  Future send_object(object){
+
+  Future send_object(object) {
     if (transaction_completed) {
-      return new Future.error(RedisRuntimeError("Transaction already completed."));
+      return new Future.error(
+          RedisRuntimeError("Transaction already completed."));
     }
 
-    Completer c= new Completer();
+    Completer c = new Completer();
     _queue.add(c);
     super.send_object(object).then((msg) {
       if (msg.toString().toLowerCase() != "queued") {
@@ -44,36 +43,37 @@ class Transaction extends Command{
     return c.future;
   }
 
-  Future discard(){
+  Future? discard() {
     _overrided_command._connection = this._connection;
     transaction_completed = true;
     return super.send_object(["DISCARD"]);
   }
-  
-  Future exec(){
+
+  Future exec() {
     _overrided_command._connection = this._connection;
     transaction_completed = true;
-    return super.send_object(["EXEC"])
-    .then((list){
-      if(list == null){ //we got explicit error from redis
-        while(_queue.isNotEmpty){
-          Completer c =_queue.removeFirst();
+    return super.send_object(["EXEC"]).then((list) {
+      if (list == null || (list.length == 1 && list[0] == null)) {
+        //we got explicit error from redis
+        while (_queue.isNotEmpty) {
+          _queue.removeFirst();
         }
         // return new Future.error(TransactionError("transaction error "));
         throw TransactionError("transaction error ");
         //return null;
-      }
-      else{
-        if(list.length != _queue.length){
-          int diff = list.length - _queue.length;
+      } else {
+        if (list.length != _queue.length) {
+          print(
+              "list.length = ${list.length} _queue.length = ${_queue.length}");
+          int? diff = list.length - _queue.length;
           //return
           throw RedisRuntimeError(
               "There was $diff command(s) executed during transcation,"
-                  "not going trough Transation handler");
+              "not going trough Transation handler");
         }
         int len = list.length;
-        for(int i=0;i<len;++i){
-          Completer c =_queue.removeFirst();
+        for (int i = 0; i < len; ++i) {
+          Completer c = _queue.removeFirst();
           c.complete(list[i]);
         }
         return "OK";

--- a/lib/transaction.dart
+++ b/lib/transaction.dart
@@ -15,7 +15,7 @@ class _WarningConnection {
 }
 
 class Transaction extends Command {
-  Queue<Completer> _queue = new Queue();
+  Queue<Completer> _queue = Queue();
   late Command _overrided_command;
   bool transaction_completed = false;
 
@@ -23,16 +23,15 @@ class Transaction extends Command {
     _overrided_command = command;
     //we override his _connection, during transaction
     //it is best to point out where problem is
-    command._connection = new _WarningConnection();
+    command._connection = _WarningConnection();
   }
 
   Future send_object(object) {
     if (transaction_completed) {
-      return new Future.error(
-          RedisRuntimeError("Transaction already completed."));
+      return Future.error(RedisRuntimeError("Transaction already completed."));
     }
 
-    Completer c = new Completer();
+    Completer c = Completer();
     _queue.add(c);
     super.send_object(object).then((msg) {
       if (msg.toString().toLowerCase() != "queued") {
@@ -58,7 +57,7 @@ class Transaction extends Command {
         while (_queue.isNotEmpty) {
           _queue.removeFirst();
         }
-        // return new Future.error(TransactionError("transaction error "));
+        // return Future.error(TransactionError("transaction error "));
         throw TransactionError("transaction error ");
         //return null;
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/ra1u/redis-dart
 issue_tracker: https://github.com/ra1u/redis-dart/issues
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dev_dependencies:
   test: ^1.6.5

--- a/test/cas_test.dart
+++ b/test/cas_test.dart
@@ -8,20 +8,20 @@ import 'main.dart';
 
 void main() {
   //group(("CAS"), () {
-    test("Test Incr CAS Multiple", () async {
-      Command cmd = await generate_connect();
+  test("Test Incr CAS Multiple", () async {
+    Command cmd = await generate_connect();
 
-      cmd.send_object(["SET", "key", "0"]);
-      Queue<Future> q = new Queue();
-      int N = 300;
-      for (int i = 0; i < N; i++) {
-        q.add(testincrcas());
-      }
+    cmd.send_object(["SET", "key", "0"]);
+    Queue<Future> q = new Queue();
+    int N = 300;
+    for (int i = 0; i < N; i++) {
+      q.add(testincrcas());
+    }
 
-      await Future.wait(q);
-      var val = await cmd.send_object(["GET", "key"]);
-      return expect(val, equals(N.toString()));
-    });
+    await Future.wait(q);
+    var val = await cmd.send_object(["GET", "key"]);
+    return expect(val, equals(N.toString()));
+  });
   //});
 }
 

--- a/test/cas_test.dart
+++ b/test/cas_test.dart
@@ -12,7 +12,7 @@ void main() {
     Command cmd = await generate_connect();
 
     cmd.send_object(["SET", "key", "0"]);
-    Queue<Future> q = new Queue();
+    Queue<Future> q = Queue();
     int N = 300;
     for (int i = 0; i < N; i++) {
       q.add(testincrcas());
@@ -27,7 +27,7 @@ void main() {
 
 Future testincrcas() {
   return generate_connect().then((Command command) {
-    Cas cas = new Cas(command);
+    Cas cas = Cas(command);
     return cas.watch(["key"], () {
       command.send_object(["GET", "key"]).then((val) {
         int i = int.parse(val);

--- a/test/docker/docker-compose.yaml
+++ b/test/docker/docker-compose.yaml
@@ -1,5 +1,3 @@
-
-
 version: "2.3"
 
 services:
@@ -10,18 +8,19 @@ services:
     image: google/dart
     depends_on:
       - redis
-    entrypoint: ["/bin/sh","-c"]
+    entrypoint: ["/bin/sh", "-c"]
     volumes:
       - "../../:/workdir"
     environment:
       - REDIS_URL=redis
       - REDIS_PORT=6379
     command:
-    - |
-       set -e #exit on falure
-       sleep 1 #todo use better approach
-       cd /workdir
-       dart pub get
-       dart analyze || true
-       dart test
-       dart test/performance.dart
+      - |
+        set -e #exit on falure
+        sleep 1 #todo use better approach
+        cd /workdir
+        dart --version
+        dart pub get
+        dart analyze || true
+        dart test
+        dart test/performance.dart

--- a/test/performance.dart
+++ b/test/performance.dart
@@ -22,9 +22,9 @@ void main() {
 
 Future<int> testing_performance(
     Future Function(int) fun, String title, int iterations) {
-  int start = new DateTime.now().millisecondsSinceEpoch;
+  int start = DateTime.now().millisecondsSinceEpoch;
   return fun(iterations).then((_) {
-    int end = new DateTime.now().millisecondsSinceEpoch;
+    int end = DateTime.now().millisecondsSinceEpoch;
 
     double diff = (end - start) / 1000.0;
     int perf = (iterations / diff).round();
@@ -46,7 +46,7 @@ Future test_pubsub_performance(int N) {
     command = cmd;
     return generate_connect();
   }).then((Command cmd) {
-    PubSub pubsub = new PubSub(cmd);
+    PubSub pubsub = PubSub(cmd);
     pubsub.subscribe(["monkey"]);
     pubsubstream = pubsub.getStream();
     return pubsubstream;
@@ -65,7 +65,7 @@ Future test_pubsub_performance(int N) {
     int counter = 0;
     //var expected = ["message", "monkey", "banana"];
     late var subscription;
-    Completer comp = new Completer();
+    Completer comp = Completer();
     subscription = pubsubstream.listen((var data) {
       counter++;
       if (counter == N) {
@@ -82,7 +82,7 @@ Future test_performance(int n, [bool piping = true]) {
   //int rec = 0;
   //int start;
   return generate_connect().then((Command command) {
-    //start = new DateTime.now().millisecondsSinceEpoch;
+    //start = DateTime.now().millisecondsSinceEpoch;
     if (piping) {
       command.pipe_start();
     }
@@ -117,7 +117,7 @@ Future test_muliconnections(int commands, int connections) {
   int K = connections;
   int c = 0;
 
-  Completer completer = new Completer();
+  Completer completer = Completer();
   generate_connect().then((Command command) {
     return command.set("var", "0");
   }).then((_) {
@@ -148,7 +148,7 @@ Future test_muliconnections(int commands, int connections) {
 //next command is executed after prevous commands completes
 //performance of this test depends on packet roundtrip time
 Future test_long_running(int n) {
-  int start = new DateTime.now().millisecondsSinceEpoch;
+  int start = DateTime.now().millisecondsSinceEpoch;
   int update_period = 2000;
   int timeout = start + update_period;
   //const String key = "keylr";
@@ -160,14 +160,14 @@ Future test_long_running(int n) {
       c++;
       if (c >= N) {
         print("  done");
-        int now = new DateTime.now().millisecondsSinceEpoch;
+        int now = DateTime.now().millisecondsSinceEpoch;
         double diff = (now - start) / 1000.0;
         double perf = c / diff;
         print("  ping-pong test performance ${perf.round()} ops/s");
         return false;
       }
       if (c % 40000 == 0) {
-        int now = new DateTime.now().millisecondsSinceEpoch;
+        int now = DateTime.now().millisecondsSinceEpoch;
         if (now > timeout) {
           timeout += update_period;
           double diff = (now - start) / 1000.0;
@@ -190,10 +190,10 @@ Future test_long_running(int n) {
 //commands wihout "memory leaking"
 //it uses multiple connections
 Future test_long_running2(int n, int k) {
-  int start = new DateTime.now().millisecondsSinceEpoch;
+  int start = DateTime.now().millisecondsSinceEpoch;
   int timeout = start + 5000;
   const String key = "keylr";
-  Completer completer = new Completer();
+  Completer completer = Completer();
   generate_connect().then((Command command) {
     int N = n;
     int c = 0;
@@ -208,10 +208,10 @@ Future test_long_running2(int n, int k) {
                 print(" done");
                 completer.complete("OK");
               }
-              return new Future(() => false);
+              return Future(() => false);
             }
 
-            int now = new DateTime.now().millisecondsSinceEpoch;
+            int now = DateTime.now().millisecondsSinceEpoch;
             if (now > timeout) {
               timeout += 5000;
               double diff = (now - start) / 1000.0;

--- a/test/performance.dart
+++ b/test/performance.dart
@@ -8,7 +8,9 @@ import 'main.dart';
 void main() {
   print("Performance TEST and REPORT");
   testing_performance(
-          test_muliconnections_con(100), "Multiple connections", 200000)
+          test_muliconnections_con(100) as Future<dynamic> Function(int),
+          "Multiple connections",
+          200000)
       .then(
           (_) => testing_performance(test_pubsub_performance, "PubSub", 200000))
       .then((_) =>
@@ -38,8 +40,8 @@ Future<int> testing_performance(
 }
 
 Future test_pubsub_performance(int N) {
-  Command command; //on conn1 tosend commands
-  Stream pubsubstream; //on conn2 to rec c
+  late Command command; //on conn1 tosend commands
+  late Stream pubsubstream; //on conn2 to rec c
   return generate_connect().then((Command cmd) {
     command = cmd;
     return generate_connect();
@@ -61,8 +63,8 @@ Future test_pubsub_performance(int N) {
     });
   }).then((_) {
     int counter = 0;
-    var expected = ["message", "monkey", "banana"];
-    var subscription;
+    //var expected = ["message", "monkey", "banana"];
+    late var subscription;
     Completer comp = new Completer();
     subscription = pubsubstream.listen((var data) {
       counter++;
@@ -77,10 +79,10 @@ Future test_pubsub_performance(int N) {
 
 Future test_performance(int n, [bool piping = true]) {
   int N = n;
-  int rec = 0;
-  int start;
+  //int rec = 0;
+  //int start;
   return generate_connect().then((Command command) {
-    start = new DateTime.now().millisecondsSinceEpoch;
+    //start = new DateTime.now().millisecondsSinceEpoch;
     if (piping) {
       command.pipe_start();
     }
@@ -120,14 +122,14 @@ Future test_muliconnections(int commands, int connections) {
     return command.set("var", "0");
   }).then((_) {
     for (int j = 0; j < K; j++) {
-      RedisConnection conn = new RedisConnection();
+      RedisConnection();
       generate_connect().then((Command command) {
         command.pipe_start();
         for (int i = j; i < N; i += K) {
           command.send_object(["INCR", "var"]).then((v) {
             c++;
             if (c == N) {
-              command.get("var").then((v) {
+              command.get("var")!.then((v) {
                 assert(v == N.toString());
                 completer.complete("ok");
               });
@@ -149,7 +151,7 @@ Future test_long_running(int n) {
   int start = new DateTime.now().millisecondsSinceEpoch;
   int update_period = 2000;
   int timeout = start + update_period;
-  const String key = "keylr";
+  //const String key = "keylr";
   return generate_connect().then((Command command) {
     int N = n;
     int c = 0;

--- a/test/pubsub_test.dart
+++ b/test/pubsub_test.dart
@@ -1,6 +1,5 @@
 // helper function to check
 // if Stream data is same as provided test Iterable
-import 'dart:async';
 import 'dart:cli';
 
 import 'package:redis/redis.dart';
@@ -28,7 +27,8 @@ void main() {
           completion(equals(["test", 1])),
           reason: "Number of subscribers should be 1 after subscription");
 
-      expect(() => cmdS.send_object("PING"),
+      expect(
+          () => cmdS.send_object("PING"),
           throwsA(equals("PubSub on this connaction in progress"
               "It is not allowed to issue commands trough this handler")),
           reason: "After subscription, command should not be able to send");
@@ -38,11 +38,14 @@ void main() {
       expect(cmdP.send_object(["PUBLISH", "test", "goodbye"]),
           completion(equals(1)));
 
-      expect(subscriber.getStream(), emitsInOrder(
-          [["subscribe", "test", 1], ["message", "test", "goodbye"]]),
+      expect(
+          subscriber.getStream(),
+          emitsInOrder([
+            ["subscribe", "test", 1],
+            ["message", "test", "goodbye"]
+          ]),
           reason: "After subscribing, the message should be received.");
     });
-
 
     test("Unsubscribe channel", () {
       expect(() => subscriber.unsubscribe(["test"]), returnsNormally,
@@ -54,7 +57,8 @@ void main() {
 
       expect(cmdP.send_object(["PUBLISH", "test", "goodbye"]),
           completion(equals(0)),
-          reason: "Publishing a message after unsubscribe should be received by zero clients.");
+          reason:
+              "Publishing a message after unsubscribe should be received by zero clients.");
 
       // TODO: Multiple channels, Pattern (un)subscribe
     });

--- a/test/transactions_test.dart
+++ b/test/transactions_test.dart
@@ -21,61 +21,54 @@ void main() {
 
     cmd2.send_object(["SET", key, "10"]);
 
-    
     for (int i = 1; i <= n; ++i) {
       trans.send_object(["INCR", key]).then((v) {
         expect(v == i, true,
             reason:
-            "Transaction value should not be interfered by actions outside of transaction");
-      })
-      .catchError((e) {
-          print("got test error $e");
-          expect(e,TypeMatcher<TransactionError>());
+                "Transaction value should not be interfered by actions outside of transaction");
+      }).catchError((e) {
+        print("got test error $e");
+        expect(e, TypeMatcher<TransactionError>());
       });
-      
+
       // Increase value out of transaction
       cmd2.send_object(["INCR", key]);
     }
-    
+
     expect(trans.send_object(["GET", key]), completion(equals(n.toString())),
         reason: "Transaction value should be final value $n");
 
     //Test using command fail during transaction
-    expect(() => cmd1.send_object(['SET', key, 0])
-      , throwsA(TypeMatcher<RedisRuntimeError>()),
+    expect(() => cmd1.send_object(['SET', key, 0]),
+        throwsA(TypeMatcher<RedisRuntimeError>()),
         reason: "Command should not be usable during transaction");
 
     expect(trans.exec(), completion(equals("OK")),
         reason: "Transaction should be executed.");
 
     expect(cmd1.send_object(["GET", key]), completion(equals(n.toString())),
-      reason: "Value should be final value $n after transaction complete");
-    
-    
+        reason: "Value should be final value $n after transaction complete");
+
     expect(() => trans.send_object(["GET", key]),
-       throwsA(TypeMatcher<RedisRuntimeError>()),
+        throwsA(TypeMatcher<RedisRuntimeError>()),
         reason:
-        "Transaction object should not be usable after finishing transaction");
+            "Transaction object should not be usable after finishing transaction");
   });
 
-  
   group("Fake CAS", () {
     test("Transaction Fake CAS", () {
       expect(() => test_incr_fakecas(), returnsNormally);
     });
-    
+
     test("Transaction Fake CAS Multiple", () {
       expect(() => test_incr_fakecas_multiple(10), returnsNormally);
     });
-    
   });
- 
-  
 }
 
 //this doesnt use Cas class, but does same functionality
 Future test_incr_fakecas() {
-  RedisConnection conn = new RedisConnection();
+  RedisConnection();
   String key = "keycaswewe";
   return generate_connect().then((Command cmd) {
     cmd.send_object(["SETNX", key, "1"]);
@@ -88,7 +81,7 @@ Future test_incr_fakecas() {
           trans.send_object(["SET", key, i.toString()]);
           return trans.exec().then((var res) {
             return false; //terminate doWhile
-        	}).catchError((e){
+          }).catchError((e) {
             return true; // try again
           });
         });

--- a/test/transactions_test.dart
+++ b/test/transactions_test.dart
@@ -91,7 +91,7 @@ Future test_incr_fakecas() {
 }
 
 Future test_incr_fakecas_multiple(int n) {
-  Queue<Future> q = new Queue();
+  Queue<Future> q = Queue();
   for (int i = 0; i < n; ++i) {
     q.add(test_incr_fakecas());
   }


### PR DESCRIPTION
Since I am using this library in my application and did not want to renounce using sound-null-safety, I tried to do the migration myself. I have been able to use this new version for my use case, and after a bit of struggle I manage to have all the test succeed. 

I mostly implemented the recommended changes of the dart migration tool, with a few notable changes.
`redisparser::parseArray` could return null values, but it seems it is not compatible with the async library, which at some point try a cast to a non-null type. So I had made parseArray return `[null]` and catch that specific value in `transaction::exec` 

The PR also includes auto formatting by my IDE, the removal of `new` keyword and the assign to then unused variables.