### PR TITLE
Added workflow to publish new version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,21 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  Publish:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+
+      - run: dart pub get
+      - run: dart test
+      - run: dart analyze
+      - run: dart pub publish --force


### PR DESCRIPTION
### Objective

Added a workflow to publish new version from Github release.

### Description

When new release/tag from Github is created, this workflow will trigger to publish new package via the command `dart pub publish --force`.

NOTE: The package admin will need to config in [package setting](https://pub.dev/packages/redis/admin) as shown in below picture.

- Enable publishing from GitHub Actions
- Enter Github repo name `<owner>/<repository>`

![Screenshot 2023-08-06 at 10 21 52 AM](https://github.com/ra1u/redis-dart/assets/42437544/72230689-9c07-4d79-ac05-5e3671ccb84e)

