### PR TITLE
refactor: 🔨 Fix typo in multiAndExec callback parameter

### DIFF
--- a/lib/cas.dart
+++ b/lib/cas.dart
@@ -43,7 +43,7 @@ class Cas {
   ///
   /// !!! DO NOT call exec() on Transaction
 
-  Future multiAndExec(Future func(Transation)) {
+  Future multiAndExec(Future func(Transaction transaction)) {
     return _cmd.multi().then((Transaction _trans) {
       func(_trans);
       return _trans.exec().then((var resp) {


### PR DESCRIPTION
Refact the parameter `Transation` to `Transaction transaction` in the `multiAndExec` callback.

This improves code readability and corrects a typo in the function signature.